### PR TITLE
シードデータの投入（Issue #5）

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,50 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# 相手（recipients）
+recipients = %w[親 パートナー 友人 兄弟・姉妹 祖父母 職場の人 その他]
+recipients.each.with_index(1) do |name, i|
+  Recipient.find_or_create_by!(name: name) do |r|
+    r.position = i
+  end
+end
+
+# きっかけ（occasions）
+occasions = [
+  "誕生日・記念日",
+  "日頃の感謝",
+  "最近助けてもらった",
+  "しばらく会えていない",
+  "特別な理由はない",
+  "その他"
+]
+occasions.each.with_index(1) do |name, i|
+  Occasion.find_or_create_by!(name: name) do |r|
+    r.position = i
+  end
+end
+
+# 印象（impressions）
+impressions = %w[いつも支えてくれる 一緒にいると安心する 自分を理解してくれる 困ったときに頼れる 笑顔にしてくれる 尊敬している 刺激をもらえる]
+impressions.each.with_index(1) do |name, i|
+  Impression.find_or_create_by!(name: name) do |r|
+    r.position = i
+  end
+end
+
+# 気持ち（feelings）
+feelings = [
+  "ありがとう",
+  "これからもよろしく",
+  "いつも助かっている",
+  "大切に思っている",
+  "ごめんね、そしてありがとう"
+]
+feelings.each.with_index(1) do |name, i|
+  Feeling.find_or_create_by!(name: name) do |r|
+    r.position = i
+  end
+end
+
+Rails.logger.info "Seed data loaded successfully!"
+Rails.logger.info "  Recipients:  #{Recipient.count}"
+Rails.logger.info "  Occasions:   #{Occasion.count}"
+Rails.logger.info "  Impressions: #{Impression.count}"
+Rails.logger.info "  Feelings:    #{Feeling.count}"

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -110,14 +110,14 @@ Tailwind CSSとHotwire（Turbo/Stimulus）を導入し、アプリケーショ�
 質問フォームの選択肢となるマスターデータ（recipients, occasions, impressions, feelings）のテーブルとモデルを作成する。
 
 ### やること
-- [ ] `recipients` テーブルのマイグレーション作成（name:string, position:integer）
-- [ ] `occasions` テーブルのマイグレーション作成（name:string, position:integer）
-- [ ] `impressions` テーブルのマイグレーション作成（name:string, position:integer）
-- [ ] `feelings` テーブルのマイグレーション作成（name:string, position:integer）
-- [ ] 各モデルファイルの作成（`Recipient`, `Occasion`, `Impression`, `Feeling`）
-- [ ] バリデーション追加（name: presence, position: presence + numericality）
-- [ ] `default_scope { order(position: :asc) }` の設定
-- [ ] モデルのユニットテスト作成
+- [x] `recipients` テーブルのマイグレーション作成（name:string, position:integer）
+- [x] `occasions` テーブルのマイグレーション作成（name:string, position:integer）
+- [x] `impressions` テーブルのマイグレーション作成（name:string, position:integer）
+- [x] `feelings` テーブルのマイグレーション作成（name:string, position:integer）
+- [x] 各モデルファイルの作成（`Recipient`, `Occasion`, `Impression`, `Feeling`）
+- [x] バリデーション追加（name: presence, position: presence + numericality）
+- [x] `default_scope { order(position: :asc) }` の設定
+- [x] モデルのユニットテスト作成
 
 ### 完了条件
 - `rails db:migrate` が成功する
@@ -135,12 +135,12 @@ Tailwind CSSとHotwire（Turbo/Stimulus）を導入し、アプリケーショ�
 マスターテーブルにMVPで使用する選択肢データを投入する。
 
 ### やること
-- [ ] `db/seeds.rb` にrecipientsデータを追加（親, パートナー, 友人, 兄弟・姉妹, 祖父母, 職場の人, その他）
-- [ ] `db/seeds.rb` にoccasionsデータを追加（誕生日・記念日, 日頃の感謝, 最近助けてもらった, しばらく会えていない, 特別な理由はない, その他）
-- [ ] `db/seeds.rb` にimpressionsデータを追加（いつも支えてくれる, 一緒にいると安心する, 自分を理解してくれる, 困ったときに頼れる, 笑顔にしてくれる, 尊敬している, 刺激をもらえる）
-- [ ] `db/seeds.rb` にfeelingsデータを追加（ありがとう, これからもよろしく, いつも助かっている, 大切に思っている, ごめんね、そしてありがとう）
-- [ ] 冪等性を考慮した実装（`find_or_create_by` の使用）
-- [ ] `rails db:seed` の動作確認
+- [x] `db/seeds.rb` にrecipientsデータを追加（親, パートナー, 友人, 兄弟・姉妹, 祖父母, 職場の人, その他）
+- [x] `db/seeds.rb` にoccasionsデータを追加（誕生日・記念日, 日頃の感謝, 最近助けてもらった, しばらく会えていない, 特別な理由はない, その他）
+- [x] `db/seeds.rb` にimpressionsデータを追加（いつも支えてくれる, 一緒にいると安心する, 自分を理解してくれる, 困ったときに頼れる, 笑顔にしてくれる, 尊敬している, 刺激をもらえる）
+- [x] `db/seeds.rb` にfeelingsデータを追加（ありがとう, これからもよろしく, いつも助かっている, 大切に思っている, ごめんね、そしてありがとう）
+- [x] 冪等性を考慮した実装（`find_or_create_by` の使用）
+- [x] `rails db:seed` の動作確認
 
 ### 完了条件
 - `rails db:seed` がエラーなく完了する


### PR DESCRIPTION
## 概要
マスターテーブル4種（recipients, occasions, impressions, feelings）にMVPで使用する選択肢データを投入するシードファイルを作成しました。

Closes #8

## やったこと
- `db/seeds.rb` に recipients（7件）、occasions（6件）、impressions（7件）、feelings（5件）のシードデータを追加
- `find_or_create_by!` を使用し、複数回実行してもデータが重複しない冪等性を確保
- `docs/issues.md` の Issue #4, #5 のチェックボックスを更新

## テスト結果
- RuboCop: 違反0件
- Brakeman: High/Medium脆弱性なし（Unmaintained Dependency の警告のみ）
- bundler-audit: Rails 7.0系の既知の警告のみ（後でアップグレード予定）
- rails test: 24 runs, 48 assertions, 0 failures

## テスト計画
- [x] `rails db:seed` がエラーなく完了する
- [x] 各テーブルに正しい件数のデータが投入されている（Recipients: 7, Occasions: 6, Impressions: 7, Feelings: 5）
- [x] `rails db:seed` を複数回実行してもデータが重複しない（冪等性確認）

## 依存Issue
- #7 マスターテーブルのモデル・マイグレーション作成（完了済み）