### PR TITLE
messagesテーブル・message_impressionsテーブルのモデル作成（Issue #6）

### DIFF
--- a/app/models/feeling.rb
+++ b/app/models/feeling.rb
@@ -1,6 +1,8 @@
 class Feeling < ApplicationRecord
   default_scope { order(position: :asc) }
 
+  has_many :messages, dependent: :restrict_with_error
+
   validates :name, presence: true
   validates :position, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/impression.rb
+++ b/app/models/impression.rb
@@ -1,6 +1,9 @@
 class Impression < ApplicationRecord
   default_scope { order(position: :asc) }
 
+  has_many :message_impressions, dependent: :restrict_with_error
+  has_many :messages, through: :message_impressions
+
   validates :name, presence: true
   validates :position, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  belongs_to :recipient
+  belongs_to :occasion
+  belongs_to :feeling
+  has_many :message_impressions, dependent: :destroy
+  has_many :impressions, through: :message_impressions
+end

--- a/app/models/message_impression.rb
+++ b/app/models/message_impression.rb
@@ -1,0 +1,4 @@
+class MessageImpression < ApplicationRecord
+  belongs_to :message
+  belongs_to :impression
+end

--- a/app/models/occasion.rb
+++ b/app/models/occasion.rb
@@ -1,6 +1,8 @@
 class Occasion < ApplicationRecord
   default_scope { order(position: :asc) }
 
+  has_many :messages, dependent: :restrict_with_error
+
   validates :name, presence: true
   validates :position, presence: true, numericality: { only_integer: true }
 end

--- a/app/models/recipient.rb
+++ b/app/models/recipient.rb
@@ -1,6 +1,8 @@
 class Recipient < ApplicationRecord
   default_scope { order(position: :asc) }
 
+  has_many :messages, dependent: :restrict_with_error
+
   validates :name, presence: true
   validates :position, presence: true, numericality: { only_integer: true }
 end

--- a/db/migrate/20260206171122_create_messages.rb
+++ b/db/migrate/20260206171122_create_messages.rb
@@ -1,0 +1,16 @@
+class CreateMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messages do |t|
+      t.bigint :user_id, null: true
+      t.references :recipient, null: false, foreign_key: true
+      t.references :occasion, null: false, foreign_key: true
+      t.references :feeling, null: false, foreign_key: true
+      t.text :episode
+      t.text :additional_message
+      t.text :generated_content
+      t.text :edited_content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260206171209_create_message_impressions.rb
+++ b/db/migrate/20260206171209_create_message_impressions.rb
@@ -1,0 +1,12 @@
+class CreateMessageImpressions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :message_impressions do |t|
+      t.references :message, null: false, foreign_key: true
+      t.references :impression, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :message_impressions, %i[message_id impression_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_02_04_121404) do
+ActiveRecord::Schema[7.0].define(version: 2026_02_06_171209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,32 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_04_121404) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "message_impressions", force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.bigint "impression_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["impression_id"], name: "index_message_impressions_on_impression_id"
+    t.index ["message_id", "impression_id"], name: "index_message_impressions_on_message_id_and_impression_id", unique: true
+    t.index ["message_id"], name: "index_message_impressions_on_message_id"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "recipient_id", null: false
+    t.bigint "occasion_id", null: false
+    t.bigint "feeling_id", null: false
+    t.text "episode"
+    t.text "additional_message"
+    t.text "generated_content"
+    t.text "edited_content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feeling_id"], name: "index_messages_on_feeling_id"
+    t.index ["occasion_id"], name: "index_messages_on_occasion_id"
+    t.index ["recipient_id"], name: "index_messages_on_recipient_id"
+  end
+
   create_table "occasions", force: :cascade do |t|
     t.string "name", null: false
     t.integer "position", null: false
@@ -42,4 +68,9 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_04_121404) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "message_impressions", "impressions"
+  add_foreign_key "message_impressions", "messages"
+  add_foreign_key "messages", "feelings"
+  add_foreign_key "messages", "occasions"
+  add_foreign_key "messages", "recipients"
 end

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -158,7 +158,7 @@ Tailwind CSSとHotwire（Turbo/Stimulus）を導入し、アプリケーショ�
 ユーザーの回答結果と生成メッセージを保存するmessagesテーブル、および多対多の中間テーブル（message_impressions）を作成する。
 
 ### やること
-- [ ] `messages` テーブルのマイグレーション作成
+- [x] `messages` テーブルのマイグレーション作成
   - user_id: bigint（nullable、外部キー）
   - recipient_id: bigint（外部キー、NOT NULL）
   - occasion_id: bigint（外部キー、NOT NULL）
@@ -168,12 +168,12 @@ Tailwind CSSとHotwire（Turbo/Stimulus）を導入し、アプリケーショ�
   - generated_content: text
   - edited_content: text（nullable）
   - timestamps
-- [ ] `message_impressions` テーブルのマイグレーション作成（message_id, impression_id）
-- [ ] `Message` モデルの作成（アソシエーション・バリデーション）
-- [ ] `MessageImpression` モデルの作成
-- [ ] `has_many :message_impressions` / `has_many :impressions, through: :message_impressions` の設定
-- [ ] マスターモデル側に `has_many :messages` を追加
-- [ ] モデルのユニットテスト作成
+- [x] `message_impressions` テーブルのマイグレーション作成（message_id, impression_id）
+- [x] `Message` モデルの作成（アソシエーション・バリデーション）
+- [x] `MessageImpression` モデルの作成
+- [x] `has_many :message_impressions` / `has_many :impressions, through: :message_impressions` の設定
+- [x] マスターモデル側に `has_many :messages` を追加
+- [x] モデルのユニットテスト作成
 
 ### 完了条件
 - `rails db:migrate` が成功する

--- a/test/models/message_impression_test.rb
+++ b/test/models/message_impression_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class MessageImpressionTest < ActiveSupport::TestCase
+  setup do
+    @recipient = Recipient.find_or_create_by!(name: "親", position: 1)
+    @occasion = Occasion.find_or_create_by!(name: "誕生日・記念日", position: 1)
+    @feeling = Feeling.find_or_create_by!(name: "ありがとう", position: 1)
+    @impression = Impression.find_or_create_by!(name: "いつも支えてくれる", position: 1)
+    @message = Message.create!(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      episode: "テストエピソード"
+    )
+  end
+
+  test "有効な属性で保存できる" do
+    mi = MessageImpression.new(message: @message, impression: @impression)
+
+    assert_predicate mi, :valid?
+  end
+
+  test "messageが未設定の場合は無効" do
+    mi = MessageImpression.new(message: nil, impression: @impression)
+
+    assert_not mi.valid?
+  end
+
+  test "impressionが未設定の場合は無効" do
+    mi = MessageImpression.new(message: @message, impression: nil)
+
+    assert_not mi.valid?
+  end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,99 @@
+require "test_helper"
+
+class MessageTest < ActiveSupport::TestCase
+  setup do
+    @recipient = Recipient.find_or_create_by!(name: "親", position: 1)
+    @occasion = Occasion.find_or_create_by!(name: "誕生日・記念日", position: 1)
+    @feeling = Feeling.find_or_create_by!(name: "ありがとう", position: 1)
+    @impression = Impression.find_or_create_by!(name: "いつも支えてくれる", position: 1)
+  end
+
+  test "有効な属性で保存できる" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      episode: "テストエピソード"
+    )
+
+    assert_predicate message, :valid?
+  end
+
+  test "recipientが未設定の場合は無効" do
+    message = Message.new(
+      recipient: nil,
+      occasion: @occasion,
+      feeling: @feeling
+    )
+
+    assert_not message.valid?
+    assert_includes message.errors[:recipient], "must exist"
+  end
+
+  test "occasionが未設定の場合は無効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: nil,
+      feeling: @feeling
+    )
+
+    assert_not message.valid?
+    assert_includes message.errors[:occasion], "must exist"
+  end
+
+  test "feelingが未設定の場合は無効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: nil
+    )
+
+    assert_not message.valid?
+    assert_includes message.errors[:feeling], "must exist"
+  end
+
+  test "impressionsを関連付けできる" do
+    message = Message.create!(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      episode: "テストエピソード"
+    )
+    message.impressions << @impression
+
+    assert_equal [@impression], message.impressions.to_a
+  end
+
+  test "additional_messageはnullでも有効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      additional_message: nil
+    )
+
+    assert_predicate message, :valid?
+  end
+
+  test "edited_contentはnullでも有効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      edited_content: nil
+    )
+
+    assert_predicate message, :valid?
+  end
+
+  test "user_idはnullでも有効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      user_id: nil
+    )
+
+    assert_predicate message, :valid?
+  end
+end


### PR DESCRIPTION
## 概要
ユーザーの回答結果と生成メッセージを保存する `messages` テーブル、および多対多の中間テーブル `message_impressions` のマイグレーション・モデルを作成しました。

Closes #9

## やったこと
- `messages` テーブルのマイグレーション作成（recipient_id, occasion_id, feeling_id の外部キー + episode, additional_message, generated_content, edited_content）
- `message_impressions` 中間テーブルのマイグレーション作成（ユニークインデックス付き）
- `Message` モデル作成（belongs_to x3, has_many :impressions through: :message_impressions）
- `MessageImpression` モデル作成（belongs_to x2）
- マスターモデル（Recipient, Occasion, Feeling, Impression）に `has_many :messages` を追加
- ユニットテスト作成（11テスト追加）

## テスト結果
- RuboCop: 違反0件
- Brakeman: High/Medium脆弱性なし（Unmaintained Dependency の警告のみ）
- bundler-audit: Rails 7.0系の既知の警告のみ（後でアップグレード予定）
- rails test: 35 runs, 65 assertions, 0 failures

## テスト計画
- [x] `rails db:migrate` が成功する
- [x] `Message` に必要なアソシエーションが正しく設定されている
- [x] `message.impressions` で関連するimpressionsを取得できる
- [x] バリデーションテストが通る（recipient, occasion, feeling の必須チェック）

## 依存Issue
- #7 マスターテーブルのモデル・マイグレーション作成（完了済み）