### PR TITLE
メッセージ生成ロジック（テンプレートエンジン）の実装（Issue #7）

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,19 @@ Metrics/BlockLength:
     - 'test/**/*'
     - 'db/migrate/*'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+    - 'spec/**/*'
+
+Metrics/ParameterLists:
+  Exclude:
+    - 'test/**/*'
+    - 'spec/**/*'
+
+Minitest/MultipleAssertions:
+  Max: 10
+
 Metrics/MethodLength:
   Max: 15
 

--- a/app/services/message_generator.rb
+++ b/app/services/message_generator.rb
@@ -1,0 +1,70 @@
+class MessageGenerator
+  HONORIFICS = {
+    "親" => "お父さん・お母さん",
+    "パートナー" => "あなた",
+    "友人" => "いつもありがとう",
+    "兄弟・姉妹" => "お兄ちゃん・お姉ちゃん",
+    "祖父母" => "おじいちゃん・おばあちゃん",
+    "職場の人" => "いつもお世話になっています"
+  }.freeze
+
+  OCCASION_TEMPLATES = {
+    "誕生日・記念日" => "特別な日に、普段なかなか言えない気持ちを伝えたくて書いています。",
+    "日頃の感謝" => "いつも当たり前のように過ごしているけれど、改めて気持ちを伝えたくなりました。",
+    "最近助けてもらった" => "最近、助けてもらったことがあって、ちゃんとお礼を伝えたいと思いました。",
+    "しばらく会えていない" => "しばらく会えていないけれど、ふと気持ちを伝えたくなりました。",
+    "特別な理由はない" => "特別な理由はないけれど、ふと気持ちを伝えたくなりました。"
+  }.freeze
+
+  FEELING_TEMPLATES = {
+    "ありがとう" => "本当にありがとう。この気持ちが届くといいな。",
+    "これからもよろしく" => "これからもよろしくね。一緒に過ごせる時間を大切にしたいです。",
+    "いつも助かっている" => "いつも本当に助かっています。あなたがいてくれることが、私の支えです。",
+    "大切に思っている" => "あなたのことを大切に思っています。これからもずっと。",
+    "ごめんね、そしてありがとう" => "素直になれないこともあるけれど、ごめんね。そして、いつもありがとう。"
+  }.freeze
+
+  def initialize(message)
+    @message = message
+    @recipient = message.recipient
+    @occasion = message.occasion
+    @impressions = message.impressions
+    @feeling = message.feeling
+    @episode = message.episode
+    @additional_message = message.additional_message
+  end
+
+  def generate
+    parts = []
+    parts << opening
+    parts << impression_section
+    parts << @episode if @episode.present?
+    parts << closing
+    parts << "P.S. #{@additional_message}" if @additional_message.present?
+    parts.compact.join("\n\n")
+  end
+
+  private
+
+  def opening
+    hon = HONORIFICS[@recipient.name]
+    prefix = hon ? "#{hon}へ\n\n" : ""
+    body = OCCASION_TEMPLATES.fetch(@occasion.name, "伝えたい気持ちがあって、書いています。")
+    "#{prefix}#{body}"
+  end
+
+  def impression_section
+    return nil if @impressions.empty?
+
+    names = @impressions.map(&:name)
+    if names.size == 1
+      "#{names.first}、そんな存在です。"
+    else
+      "#{names[0..-2].join("、")}、そして#{names.last}。そんな存在です。"
+    end
+  end
+
+  def closing
+    FEELING_TEMPLATES.fetch(@feeling.name, "ありがとう。")
+  end
+end

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -192,15 +192,15 @@ Tailwind CSSとHotwire（Turbo/Stimulus）を導入し、アプリケーショ�
 ユーザーの回答に基づいてメッセージを生成するサービスクラスを実装する。条件分岐によるテンプレートベースの文章生成ロジック。
 
 ### やること
-- [ ] `app/services/message_generator.rb` の作成
-- [ ] recipient（相手）に応じた呼称・敬称の分岐ロジック
-- [ ] occasion（きっかけ）に応じた導入文のテンプレート
-- [ ] impressions（印象・複数）を文章に組み込むロジック
-- [ ] episode（エピソード）を自然に挿入するロジック
-- [ ] feeling（気持ち）に応じた締めくくり文のテンプレート
-- [ ] additional_message（追加メッセージ）がある場合の挿入ロジック
-- [ ] 各条件分岐の組み合わせテスト
-- [ ] サービスクラスのユニットテスト作成（主要パターンを網羅）
+- [x] `app/services/message_generator.rb` の作成
+- [x] recipient（相手）に応じた呼称・敬称の分岐ロジック
+- [x] occasion（きっかけ）に応じた導入文のテンプレート
+- [x] impressions（印象・複数）を文章に組み込むロジック
+- [x] episode（エピソード）を自然に挿入するロジック
+- [x] feeling（気持ち）に応じた締めくくり文のテンプレート
+- [x] additional_message（追加メッセージ）がある場合の挿入ロジック
+- [x] 各条件分岐の組み合わせテスト
+- [x] サービスクラスのユニットテスト作成（主要パターンを網羅）
 
 ### 完了条件
 - `MessageGenerator.new(message).generate` で文章が生成される

--- a/test/services/message_generator_test.rb
+++ b/test/services/message_generator_test.rb
@@ -1,0 +1,276 @@
+require "test_helper"
+
+class MessageGeneratorTest < ActiveSupport::TestCase
+  setup do
+    @recipient_parent = Recipient.find_or_create_by!(name: "親", position: 1)
+    @recipient_partner = Recipient.find_or_create_by!(name: "パートナー", position: 2)
+    @recipient_friend = Recipient.find_or_create_by!(name: "友人", position: 3)
+    @recipient_sibling = Recipient.find_or_create_by!(name: "兄弟・姉妹", position: 4)
+    @recipient_grandparent = Recipient.find_or_create_by!(name: "祖父母", position: 5)
+    @recipient_colleague = Recipient.find_or_create_by!(name: "職場の人", position: 6)
+    @recipient_other = Recipient.find_or_create_by!(name: "その他", position: 7)
+
+    @occasion_birthday = Occasion.find_or_create_by!(name: "誕生日・記念日", position: 1)
+    @occasion_thanks = Occasion.find_or_create_by!(name: "日頃の感謝", position: 2)
+    @occasion_helped = Occasion.find_or_create_by!(name: "最近助けてもらった", position: 3)
+    @occasion_apart = Occasion.find_or_create_by!(name: "しばらく会えていない", position: 4)
+    @occasion_noreason = Occasion.find_or_create_by!(name: "特別な理由はない", position: 5)
+    @occasion_other = Occasion.find_or_create_by!(name: "その他", position: 6)
+
+    @impression1 = Impression.find_or_create_by!(name: "いつも支えてくれる", position: 1)
+    @impression2 = Impression.find_or_create_by!(name: "一緒にいると安心する", position: 2)
+    @impression3 = Impression.find_or_create_by!(name: "笑顔にしてくれる", position: 3)
+
+    @feeling_thanks = Feeling.find_or_create_by!(name: "ありがとう", position: 1)
+    @feeling_yoroshiku = Feeling.find_or_create_by!(name: "これからもよろしく", position: 2)
+    @feeling_tasukaru = Feeling.find_or_create_by!(name: "いつも助かっている", position: 3)
+    @feeling_taisetsu = Feeling.find_or_create_by!(name: "大切に思っている", position: 4)
+    @feeling_gomenne = Feeling.find_or_create_by!(name: "ごめんね、そしてありがとう", position: 5)
+  end
+
+  def build_message(recipient: nil, occasion: nil, feeling: nil, impressions: [], episode: nil, additional_message: nil)
+    msg = Message.create!(
+      recipient: recipient || @recipient_parent,
+      occasion: occasion || @occasion_thanks,
+      feeling: feeling || @feeling_thanks,
+      episode: episode,
+      additional_message: additional_message
+    )
+    impressions.each { |imp| msg.impressions << imp }
+    msg
+  end
+
+  # --- 基本動作 ---
+
+  test "generateでメッセージ文字列が生成される" do
+    message = build_message(impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_kind_of String, result
+    assert_predicate result, :present?
+  end
+
+  # --- recipient に応じた呼称 ---
+
+  test "親の場合はお父さん・お母さんへの呼称が含まれる" do
+    message = build_message(recipient: @recipient_parent, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/お父さん・お母さんへ/, result)
+  end
+
+  test "パートナーの場合はあなたへの呼称が含まれる" do
+    message = build_message(recipient: @recipient_partner, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/あなたへ/, result)
+  end
+
+  test "友人の場合の呼称が含まれる" do
+    message = build_message(recipient: @recipient_friend, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/いつもありがとうへ/, result)
+  end
+
+  test "祖父母の場合の呼称が含まれる" do
+    message = build_message(recipient: @recipient_grandparent, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/おじいちゃん・おばあちゃんへ/, result)
+  end
+
+  test "職場の人の場合の呼称が含まれる" do
+    message = build_message(recipient: @recipient_colleague, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/いつもお世話になっていますへ/, result)
+  end
+
+  test "その他の場合は呼称なしで始まる" do
+    message = build_message(recipient: @recipient_other, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_no_match(/へ\n/, result)
+  end
+
+  # --- occasion に応じた導入文 ---
+
+  test "誕生日・記念日の導入文が生成される" do
+    message = build_message(occasion: @occasion_birthday, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/特別な日に/, result)
+  end
+
+  test "日頃の感謝の導入文が生成される" do
+    message = build_message(occasion: @occasion_thanks, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/改めて気持ちを伝えたく/, result)
+  end
+
+  test "最近助けてもらったの導入文が生成される" do
+    message = build_message(occasion: @occasion_helped, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/助けてもらったことがあって/, result)
+  end
+
+  test "しばらく会えていないの導入文が生成される" do
+    message = build_message(occasion: @occasion_apart, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/しばらく会えていないけれど/, result)
+  end
+
+  test "特別な理由はないの導入文が生成される" do
+    message = build_message(occasion: @occasion_noreason, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/特別な理由はないけれど/, result)
+  end
+
+  test "その他のoccasionの導入文が生成される" do
+    message = build_message(occasion: @occasion_other, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/伝えたい気持ちがあって/, result)
+  end
+
+  # --- impressions ---
+
+  test "impression1つの場合は自然な文章になる" do
+    message = build_message(impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/いつも支えてくれる、そんな存在です。/, result)
+  end
+
+  test "impression2つの場合は自然に結合される" do
+    message = build_message(impressions: [@impression1, @impression2])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/いつも支えてくれる、そして一緒にいると安心する。そんな存在です。/, result)
+  end
+
+  test "impression3つの場合は自然に結合される" do
+    message = build_message(impressions: [@impression1, @impression2, @impression3])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/いつも支えてくれる、一緒にいると安心する、そして笑顔にしてくれる。そんな存在です。/, result)
+  end
+
+  test "impressionが0個の場合は印象セクションが含まれない" do
+    message = build_message(impressions: [])
+    result = MessageGenerator.new(message).generate
+
+    assert_no_match(/そんな存在です/, result)
+  end
+
+  # --- episode ---
+
+  test "エピソードが含まれる" do
+    message = build_message(impressions: [@impression1], episode: "先日、体調を崩したときにそばにいてくれました。")
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/先日、体調を崩したときにそばにいてくれました。/, result)
+  end
+
+  test "エピソードが空の場合はエピソードセクションが含まれない" do
+    message = build_message(impressions: [@impression1], episode: nil)
+    result = MessageGenerator.new(message).generate
+
+    # 導入文 + 印象 + 締めのみ
+    assert_match(/お父さん・お母さんへ/, result)
+    assert_match(/そんな存在です/, result)
+  end
+
+  # --- feeling ---
+
+  test "ありがとうの締めくくりが生成される" do
+    message = build_message(feeling: @feeling_thanks, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/本当にありがとう/, result)
+  end
+
+  test "これからもよろしくの締めくくりが生成される" do
+    message = build_message(feeling: @feeling_yoroshiku, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/これからもよろしくね/, result)
+  end
+
+  test "いつも助かっているの締めくくりが生成される" do
+    message = build_message(feeling: @feeling_tasukaru, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/いつも本当に助かっています/, result)
+  end
+
+  test "大切に思っているの締めくくりが生成される" do
+    message = build_message(feeling: @feeling_taisetsu, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/大切に思っています/, result)
+  end
+
+  test "ごめんね、そしてありがとうの締めくくりが生成される" do
+    message = build_message(feeling: @feeling_gomenne, impressions: [@impression1])
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/ごめんね。そして、いつもありがとう/, result)
+  end
+
+  # --- additional_message ---
+
+  test "追加メッセージがある場合はP.S.として追加される" do
+    message = build_message(impressions: [@impression1], additional_message: "今度ご飯行こうね！")
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/P\.S\. 今度ご飯行こうね！/, result)
+  end
+
+  test "追加メッセージがない場合はP.S.が含まれない" do
+    message = build_message(impressions: [@impression1], additional_message: nil)
+    result = MessageGenerator.new(message).generate
+
+    assert_no_match(/P\.S\./, result)
+  end
+
+  # --- 組み合わせテスト ---
+
+  test "全要素を含むメッセージが正しく生成される" do
+    message = build_message(
+      recipient: @recipient_parent,
+      occasion: @occasion_birthday,
+      feeling: @feeling_thanks,
+      impressions: [@impression1, @impression2],
+      episode: "いつも応援してくれてありがとう。",
+      additional_message: "また帰るね。"
+    )
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/お父さん・お母さんへ/, result)
+    assert_match(/特別な日に/, result)
+    assert_match(/いつも支えてくれる、そして一緒にいると安心する/, result)
+    assert_match(/いつも応援してくれてありがとう。/, result)
+    assert_match(/本当にありがとう/, result)
+    assert_match(/P\.S\. また帰るね。/, result)
+  end
+
+  test "recipientとoccasionの異なる組み合わせで導入文が変化する" do
+    msg1 = build_message(recipient: @recipient_partner, occasion: @occasion_birthday, impressions: [@impression1])
+    msg2 = build_message(recipient: @recipient_partner, occasion: @occasion_apart, impressions: [@impression1])
+
+    result1 = MessageGenerator.new(msg1).generate
+    result2 = MessageGenerator.new(msg2).generate
+
+    assert_match(/特別な日に/, result1)
+    assert_match(/しばらく会えていないけれど/, result2)
+    # 両方にパートナーの呼称が含まれる
+    assert_match(/あなたへ/, result1)
+    assert_match(/あなたへ/, result2)
+  end
+end


### PR DESCRIPTION
## 概要
ユーザーの回答に基づいてメッセージを生成する `MessageGenerator` サービスクラスを実装しました。条件分岐によるテンプレートベースの文章生成ロジックです。

Closes #10

## やったこと
- `app/services/message_generator.rb` の作成
- recipient（相手）に応じた呼称・敬称の分岐ロジック（7パターン）
- occasion（きっかけ）に応じた導入文テンプレート（6パターン）
- impressions（印象・複数）を自然な文章に組み込むロジック
- episode（エピソード）の挿入ロジック
- feeling（気持ち）に応じた締めくくり文テンプレート（5パターン）
- additional_message がある場合の P.S. 挿入ロジック
- `.rubocop.yml` にテスト用のメトリクス緩和設定を追加
- ユニットテスト28件作成（主要パターン網羅）

## テスト結果
- RuboCop: 違反0件
- Brakeman: High/Medium脆弱性なし（Unmaintained Dependency の警告のみ）
- bundler-audit: Rails 7.0系の既知の警告のみ（後でアップグレード予定）
- rails test: 63 runs, 139 assertions, 0 failures

## テスト計画
- [x] `MessageGenerator.new(message).generate` で文章が生成される
- [x] recipientとoccasionの組み合わせに応じて導入文が変化する
- [x] impressionsが複数選択された場合に自然な文章になる
- [x] episodeが文中に適切に組み込まれる
- [x] feelingに応じた締めくくりが生成される
- [x] additional_messageが任意で文末に追加される
- [x] ユニットテストが全て通る

## 依存Issue
- #8 シードデータの投入（完了済み）
- #9 messagesテーブル・message_impressionsテーブルのモデル作成（完了済み）