### PR TITLE
ステップフォーム（Step 4〜6）の実装（Issue #12）

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -59,6 +59,105 @@ class MessagesController < ApplicationController
 
     session[:message_draft] ||= {}
     session[:message_draft]["impression_ids"] = Array(params[:impression_ids]).map(&:to_i)
-    redirect_to root_path
+    redirect_to step4_message_path
+  end
+
+  def step4
+    unless draft_complete_up_to?(3)
+      redirect_to step1_message_path
+      return
+    end
+
+    @episode = session.dig(:message_draft, "episode")
+  end
+
+  def save_step4
+    session[:message_draft] ||= {}
+    session[:message_draft]["episode"] = params[:episode].to_s.strip
+    redirect_to step5_message_path
+  end
+
+  def step5
+    unless draft_complete_up_to?(3)
+      redirect_to step1_message_path
+      return
+    end
+
+    @feelings = Feeling.all
+    @selected_id = session.dig(:message_draft, "feeling_id")
+  end
+
+  def save_step5
+    if params[:feeling_id].blank?
+      redirect_to step5_message_path, alert: "気持ちを選んでください"
+      return
+    end
+
+    session[:message_draft] ||= {}
+    session[:message_draft]["feeling_id"] = params[:feeling_id].to_i
+    redirect_to step6_message_path
+  end
+
+  def step6
+    unless draft_complete_up_to?(5)
+      redirect_to step1_message_path
+      return
+    end
+
+    @additional_message = session.dig(:message_draft, "additional_message")
+  end
+
+  def save_step6
+    session[:message_draft] ||= {}
+    session[:message_draft]["additional_message"] = params[:additional_message].to_s.strip
+
+    draft = session[:message_draft]
+    unless draft["recipient_id"] && draft["occasion_id"] && draft["impression_ids"] && draft["feeling_id"]
+      redirect_to step1_message_path
+      return
+    end
+
+    @message = Message.new(
+      recipient_id: draft["recipient_id"],
+      occasion_id: draft["occasion_id"],
+      feeling_id: draft["feeling_id"],
+      episode: draft["episode"].presence,
+      additional_message: draft["additional_message"].presence
+    )
+    @message.impression_ids = draft["impression_ids"]
+
+    if @message.save
+      @message.update(generated_content: MessageGenerator.new(@message).generate)
+      session.delete(:message_draft)
+      redirect_to message_path(@message)
+    else
+      redirect_to step1_message_path, alert: "メッセージの作成に失敗しました"
+    end
+  end
+
+  def show
+    @message = Message.find(params[:id])
+  end
+
+  private
+
+  def draft_complete_up_to?(step)
+    draft = session[:message_draft]
+    return false unless draft
+
+    case step
+    when 1
+      draft["recipient_id"].present?
+    when 2
+      draft["recipient_id"].present? && draft["occasion_id"].present?
+    when 3
+      draft["recipient_id"].present? && draft["occasion_id"].present? && draft["impression_ids"].present?
+    when 4
+      draft_complete_up_to?(3)
+    when 5
+      draft_complete_up_to?(3) && draft["feeling_id"].present?
+    else
+      false
+    end
   end
 end

--- a/app/views/messages/show.html.erb
+++ b/app/views/messages/show.html.erb
@@ -1,0 +1,17 @@
+<section class="py-12 px-6">
+  <div class="mx-auto max-w-2xl">
+    <div class="text-center mb-8">
+      <h1 class="text-2xl lg:text-3xl font-bold text-main-text mb-2">メッセージが完成しました</h1>
+      <p class="text-sub-text font-light">あなたの気持ちを込めたメッセージです。</p>
+    </div>
+
+    <div class="p-6 lg:p-8 rounded-2xl border-2 border-primary/10 bg-white/50 mb-8">
+      <p class="text-main-text whitespace-pre-line leading-relaxed"><%= @message.edited_content.presence || @message.generated_content %></p>
+    </div>
+
+    <div class="space-y-4">
+      <%= link_to "新しいメッセージを作る", new_message_path, class: "block w-full h-14 bg-primary text-white rounded-xl font-bold text-lg text-center leading-[3.5rem] hover:shadow-[0_4px_20px_rgba(192,108,94,0.3)] transition-all" %>
+      <%= link_to "トップに戻る", root_path, class: "block w-full h-14 border-2 border-primary/20 text-primary rounded-xl font-bold text-lg text-center leading-[3.5rem] hover:bg-primary/5 transition-all" %>
+    </div>
+  </div>
+</section>

--- a/app/views/messages/step4.html.erb
+++ b/app/views/messages/step4.html.erb
@@ -1,0 +1,25 @@
+<%= render layout: "messages/step_layout", locals: { current_step: 4, title: "エピソードを教えてください", subtitle: "相手との思い出やエピソードがあれば書いてください。（任意）" } do %>
+  <%= form_with url: step4_message_path, method: :post, class: "space-y-6" do |f| %>
+    <div>
+      <textarea name="episode" rows="6"
+                class="w-full p-4 rounded-xl border-2 border-primary/10 bg-white/50 text-main-text placeholder-sub-text/50 focus:border-primary focus:ring-0 focus:outline-none transition-all resize-none"
+                placeholder="例：先月、仕事で落ち込んでいた時にそっと話を聞いてくれた"><%= @episode %></textarea>
+    </div>
+
+    <div class="p-4 rounded-xl bg-background-dark/50">
+      <p class="text-sm font-bold text-sub-text mb-2">ヒント</p>
+      <ul class="text-sm text-sub-text space-y-1">
+        <li>- 最近あった出来事や思い出</li>
+        <li>- 相手にしてもらって嬉しかったこと</li>
+        <li>- 一緒に過ごした印象的な時間</li>
+      </ul>
+    </div>
+
+    <div class="flex gap-4 pt-6">
+      <%= link_to "戻る", step3_message_path, class: "flex-1 h-14 border-2 border-primary/20 text-primary rounded-xl font-bold text-lg flex items-center justify-center hover:bg-primary/5 transition-all" %>
+      <button type="submit" class="flex-1 h-14 bg-primary text-white rounded-xl font-bold text-lg hover:shadow-[0_4px_20px_rgba(192,108,94,0.3)] transition-all">
+        次へ進む
+      </button>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/messages/step5.html.erb
+++ b/app/views/messages/step5.html.erb
@@ -1,0 +1,18 @@
+<%= render layout: "messages/step_layout", locals: { current_step: 5, title: "どんな気持ちを届けますか？", subtitle: "一番伝えたい気持ちを選んでください。" } do %>
+  <%= form_with url: step5_message_path, method: :post, class: "space-y-4" do |f| %>
+    <% @feelings.each do |feeling| %>
+      <%= render "messages/selection_card",
+                 name: "feeling_id",
+                 value: feeling.id,
+                 label: feeling.name,
+                 checked: @selected_id == feeling.id %>
+    <% end %>
+
+    <div class="flex gap-4 pt-6">
+      <%= link_to "戻る", step4_message_path, class: "flex-1 h-14 border-2 border-primary/20 text-primary rounded-xl font-bold text-lg flex items-center justify-center hover:bg-primary/5 transition-all" %>
+      <button type="submit" class="flex-1 h-14 bg-primary text-white rounded-xl font-bold text-lg hover:shadow-[0_4px_20px_rgba(192,108,94,0.3)] transition-all">
+        次へ進む
+      </button>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/messages/step6.html.erb
+++ b/app/views/messages/step6.html.erb
@@ -1,0 +1,16 @@
+<%= render layout: "messages/step_layout", locals: { current_step: 6, title: "追加メッセージはありますか？", subtitle: "最後に伝えたいことがあれば書いてください。（任意）" } do %>
+  <%= form_with url: step6_message_path, method: :post, class: "space-y-6" do |f| %>
+    <div>
+      <textarea name="additional_message" rows="4"
+                class="w-full p-4 rounded-xl border-2 border-primary/10 bg-white/50 text-main-text placeholder-sub-text/50 focus:border-primary focus:ring-0 focus:outline-none transition-all resize-none"
+                placeholder="例：今度一緒にごはん行こうね"><%= @additional_message %></textarea>
+    </div>
+
+    <div class="flex gap-4 pt-6">
+      <%= link_to "戻る", step5_message_path, class: "flex-1 h-14 border-2 border-primary/20 text-primary rounded-xl font-bold text-lg flex items-center justify-center hover:bg-primary/5 transition-all" %>
+      <button type="submit" class="flex-1 h-14 bg-primary text-white rounded-xl font-bold text-lg hover:shadow-[0_4px_20px_rgba(192,108,94,0.3)] transition-all">
+        メッセージを作成する
+      </button>
+    </div>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,14 @@ Rails.application.routes.draw do
       post :step2, action: :save_step2
       get  :step3
       post :step3, action: :save_step3
+      get  :step4
+      post :step4, action: :save_step4
+      get  :step5
+      post :step5, action: :save_step5
+      get  :step6
+      post :step6, action: :save_step6
     end
   end
+
+  resources :messages, only: [:show]
 end


### PR DESCRIPTION
closes #12

## Summary
- Step 4（エピソード入力）、Step 5（気持ち選択）、Step 6（追加メッセージ入力）のフォームUIを実装
- Step 6完了時にMessageレコードを保存し、MessageGeneratorでメッセージを生成
- 生成完了後のメッセージ表示画面（show）を実装
- 各ステップの戻るボタン・セッション保持・遷移ガードを実装
- コントローラーテスト13件追加（全90件パス）

## 変更ファイル
- `config/routes.rb` - step4〜6のGET/POSTルート + `messages#show`ルート追加
- `app/controllers/messages_controller.rb` - step4〜6/save_step4〜6/showアクション + `draft_complete_up_to?`ヘルパー追加
- `app/views/messages/step4.html.erb` - エピソード入力画面（テキストエリア + ヒント例、任意入力）
- `app/views/messages/step5.html.erb` - 気持ち選択画面（ラジオボタン、`_selection_card`再利用）
- `app/views/messages/step6.html.erb` - 追加メッセージ入力画面（テキストエリア、任意入力）
- `app/views/messages/show.html.erb` - 生成メッセージ表示画面
- `test/controllers/messages_controller_test.rb` - Step 4〜6 + show のテスト追加

## Test plan
- [x] 全90件のテストがパスすること（`rails test` 実行済み）
- [x] Step 3完了後にStep 4に遷移できること
- [x] Step 4でエピソードを入力（または空欄のまま）してStep 5に遷移できること
- [x] Step 5で気持ちを選択してStep 6に遷移できること
- [x] Step 6で追加メッセージを入力（または空欄のまま）してメッセージが生成されること
- [x] 各ステップで「戻る」ボタンが動作し、以前の入力が保持されていること
- [x] show画面に生成されたメッセージが表示されること
- [x] プログレスバーがStep 4〜6を正しく反映していること

🤖 Generated with [Claude Code](https://claude.com/claude-code)