### PR TITLE
宛名の改善: Step 1を二段階選択に (#54)

### DIFF
--- a/app/controllers/concerns/message_draft.rb
+++ b/app/controllers/concerns/message_draft.rb
@@ -49,7 +49,8 @@ module MessageDraft
       occasion_id: draft["occasion_id"],
       feeling_id: draft["feeling_id"],
       episode: draft["episode"].presence,
-      additional_message: draft["additional_message"].presence
+      additional_message: draft["additional_message"].presence,
+      recipient_name: draft["recipient_name"].presence
     )
     message.impression_ids = draft["impression_ids"]
     message

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -29,6 +29,7 @@ class MessagesController < ApplicationController
   def step1
     @recipients = Recipient.all
     @selected_id = session.dig(:message_draft, "recipient_id")
+    @selected_name = session.dig(:message_draft, "recipient_name")
   end
 
   def save_step1
@@ -38,6 +39,7 @@ class MessagesController < ApplicationController
     end
 
     save_draft("recipient_id", params[:recipient_id].to_i)
+    save_draft("recipient_name", params[:recipient_name].to_s.strip)
     redirect_to step2_message_path
   end
 

--- a/app/javascript/controllers/recipient_name_controller.js
+++ b/app/javascript/controllers/recipient_name_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["nameSection", "chipContainer", "nameInput", "hiddenInput", "submitButton"]
+  static values = { chips: Object }
+
+  selectCategory(event) {
+    const categoryName = event.target.closest("label").querySelector("span").textContent.trim()
+    this.showNameSection(categoryName)
+  }
+
+  showNameSection(categoryName) {
+    const chips = this.chipsValue[categoryName] || []
+
+    this.chipContainerTarget.innerHTML = ""
+    chips.forEach(name => {
+      const chip = document.createElement("button")
+      chip.type = "button"
+      chip.textContent = name
+      chip.className = "px-4 py-2 rounded-full border-2 border-primary/20 bg-white text-main-text font-medium hover:border-primary hover:bg-primary/5 transition-all cursor-pointer"
+      chip.addEventListener("click", () => this.selectChip(name))
+      this.chipContainerTarget.appendChild(chip)
+    })
+
+    this.nameInputTarget.value = ""
+    this.hiddenInputTarget.value = ""
+    this.nameSectionTarget.classList.remove("hidden")
+    this.updateSubmitButton()
+  }
+
+  selectChip(name) {
+    this.hiddenInputTarget.value = name
+    this.nameInputTarget.value = ""
+
+    this.chipContainerTarget.querySelectorAll("button").forEach(btn => {
+      if (btn.textContent === name) {
+        btn.classList.add("border-primary", "bg-primary/5", "shadow-md")
+        btn.classList.remove("border-primary/20")
+      } else {
+        btn.classList.remove("border-primary", "bg-primary/5", "shadow-md")
+        btn.classList.add("border-primary/20")
+      }
+    })
+    this.updateSubmitButton()
+  }
+
+  inputName() {
+    this.hiddenInputTarget.value = this.nameInputTarget.value.trim()
+
+    this.chipContainerTarget.querySelectorAll("button").forEach(btn => {
+      btn.classList.remove("border-primary", "bg-primary/5", "shadow-md")
+      btn.classList.add("border-primary/20")
+    })
+    this.updateSubmitButton()
+  }
+
+  updateSubmitButton() {
+    if (this.hasSubmitButtonTarget) {
+      this.submitButtonTarget.disabled = !this.hiddenInputTarget.value
+    }
+  }
+}

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -10,4 +10,5 @@ class Message < ApplicationRecord
 
   validates :episode, length: { maximum: EPISODE_MAX_LENGTH }
   validates :additional_message, length: { maximum: ADDITIONAL_MESSAGE_MAX_LENGTH }
+  validates :recipient_name, length: { maximum: 20 }
 end

--- a/app/services/message_generator.rb
+++ b/app/services/message_generator.rb
@@ -130,8 +130,12 @@ class MessageGenerator # rubocop:disable Metrics/ClassLength
   private
 
   def opening
-    hon = HONORIFICS[@recipient.name]
-    prefix = hon ? "#{hon}へ\n\n" : ""
+    prefix = if @message.recipient_name.present?
+               "#{@message.recipient_name}へ\n\n"
+             else
+               hon = HONORIFICS[@recipient.name]
+               hon ? "#{hon}へ\n\n" : ""
+             end
     templates = OCCASION_TEMPLATES[@occasion.name]
     body = if templates
              templates.sample

--- a/app/views/messages/_selection_card.html.erb
+++ b/app/views/messages/_selection_card.html.erb
@@ -1,5 +1,5 @@
 <label class="relative block cursor-pointer">
-  <input type="radio" name="<%= name %>" value="<%= value %>" class="peer absolute opacity-0 w-0 h-0" <%= "checked" if checked %>>
+  <input type="radio" name="<%= name %>" value="<%= value %>" class="peer absolute opacity-0 w-0 h-0" <%= "checked" if checked %> <%= "data-action=#{action}" if local_assigns[:action] %>>
   <div class="p-5 rounded-xl border-2 border-primary/10 bg-white/50 transition-all
               peer-checked:border-primary peer-checked:bg-primary/5 peer-checked:shadow-md
               hover:border-primary/30 hover:shadow-sm">

--- a/app/views/messages/step1.html.erb
+++ b/app/views/messages/step1.html.erb
@@ -1,15 +1,45 @@
 <%= render layout: "messages/step_layout", locals: { current_step: 1, title: "誰に届けますか？", subtitle: "メッセージを届けたい相手を選んでください。" } do %>
-  <%= form_with url: step1_message_path, method: :post, class: "space-y-4" do |f| %>
+  <%
+    chip_data = {
+      "親" => ["お父さん", "お母さん"],
+      "兄弟・姉妹" => ["お兄ちゃん", "お姉ちゃん"],
+      "祖父母" => ["おじいちゃん", "おばあちゃん"]
+    }
+  %>
+  <%= form_with url: step1_message_path, method: :post, class: "space-y-4",
+                data: { controller: "recipient-name", "recipient-name-chips-value": chip_data.to_json } do |f| %>
     <% @recipients.each do |recipient| %>
       <%= render "messages/selection_card",
                  name: "recipient_id",
                  value: recipient.id,
                  label: recipient.name,
-                 checked: @selected_id == recipient.id %>
+                 checked: @selected_id == recipient.id,
+                 action: "change->recipient-name#selectCategory" %>
     <% end %>
 
+    <div data-recipient-name-target="nameSection" class="hidden space-y-4 pt-2">
+      <p class="text-sub-text font-light text-sm">どう呼んでいますか？（宛名に使います）</p>
+
+      <div data-recipient-name-target="chipContainer" class="flex flex-wrap gap-2"></div>
+
+      <div>
+        <input type="text"
+               data-recipient-name-target="nameInput"
+               data-action="input->recipient-name#inputName"
+               placeholder="自由に入力（例：ママ、太郎くん）"
+               maxlength="20"
+               class="w-full px-4 py-3 rounded-xl border-2 border-primary/10 bg-white/50 text-main-text
+                      focus:border-primary focus:outline-none transition-all"
+               <% if @selected_name.present? %>value="<%= @selected_name %>"<% end %>>
+      </div>
+
+      <input type="hidden" name="recipient_name" data-recipient-name-target="hiddenInput"
+             <% if @selected_name.present? %>value="<%= @selected_name %>"<% end %>>
+    </div>
+
     <div class="pt-6">
-      <button type="submit" class="w-full h-14 bg-primary text-white rounded-xl font-bold text-lg hover:shadow-[0_4px_20px_rgba(192,108,94,0.3)] transition-all">
+      <button type="submit" data-recipient-name-target="submitButton"
+              class="w-full h-14 bg-primary text-white rounded-xl font-bold text-lg hover:shadow-[0_4px_20px_rgba(192,108,94,0.3)] transition-all disabled:opacity-50 disabled:cursor-not-allowed">
         次へ進む
       </button>
     </div>

--- a/db/migrate/20260221074005_add_recipient_name_to_messages.rb
+++ b/db/migrate/20260221074005_add_recipient_name_to_messages.rb
@@ -1,0 +1,5 @@
+class AddRecipientNameToMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :messages, :recipient_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_02_06_171209) do
+ActiveRecord::Schema[7.0].define(version: 2026_02_21_074005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2026_02_06_171209) do
     t.text "edited_content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "recipient_name"
     t.index ["feeling_id"], name: "index_messages_on_feeling_id"
     t.index ["occasion_id"], name: "index_messages_on_occasion_id"
     t.index ["recipient_id"], name: "index_messages_on_recipient_id"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -23,6 +23,13 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to step2_message_path
   end
 
+  test "save_step1 saves recipient_name in session" do
+    recipient = recipients(:parent)
+    post step1_message_path, params: { recipient_id: recipient.id, recipient_name: "お母さん" }
+
+    assert_redirected_to step2_message_path
+  end
+
   test "save_step1 redirects back when no recipient selected" do
     post step1_message_path, params: { recipient_id: "" }
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -142,4 +142,38 @@ class MessageTest < ActiveSupport::TestCase
     assert_not message.valid?
     assert_includes message.errors[:additional_message], "は200文字以内で入力してください"
   end
+
+  test "recipient_nameが20文字以内なら有効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      recipient_name: "あ" * 20
+    )
+
+    assert_predicate message, :valid?
+  end
+
+  test "recipient_nameが21文字以上なら無効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      recipient_name: "あ" * 21
+    )
+
+    assert_not message.valid?
+    assert_includes message.errors[:recipient_name], "は20文字以内で入力してください"
+  end
+
+  test "recipient_nameはnullでも有効" do
+    message = Message.new(
+      recipient: @recipient,
+      occasion: @occasion,
+      feeling: @feeling,
+      recipient_name: nil
+    )
+
+    assert_predicate message, :valid?
+  end
 end

--- a/test/services/message_generator_test.rb
+++ b/test/services/message_generator_test.rb
@@ -28,13 +28,16 @@ class MessageGeneratorTest < ActiveSupport::TestCase
     @feeling_gomenne = Feeling.find_or_create_by!(name: "ごめんね、そしてありがとう", position: 5)
   end
 
-  def build_message(recipient: nil, occasion: nil, feeling: nil, impressions: [], episode: nil, additional_message: nil)
+  def build_message(recipient: nil, occasion: nil, feeling: nil,
+                    impressions: [], episode: nil, additional_message: nil,
+                    recipient_name: nil)
     msg = Message.create!(
       recipient: recipient || @recipient_parent,
       occasion: occasion || @occasion_thanks,
       feeling: feeling || @feeling_thanks,
       episode: episode,
-      additional_message: additional_message
+      additional_message: additional_message,
+      recipient_name: recipient_name
     )
     impressions.each { |imp| msg.impressions << imp }
     msg
@@ -92,6 +95,21 @@ class MessageGeneratorTest < ActiveSupport::TestCase
     result = MessageGenerator.new(message).generate
 
     assert_no_match(/へ\n/, result)
+  end
+
+  test "recipient_nameが指定されている場合はその宛名が使われる" do
+    message = build_message(recipient: @recipient_parent, impressions: [@impression1], recipient_name: "お母さん")
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/お母さんへ/, result)
+    assert_no_match(/お父さん・お母さんへ/, result)
+  end
+
+  test "recipient_nameが空の場合はHONORIFICSフォールバックが使われる" do
+    message = build_message(recipient: @recipient_parent, impressions: [@impression1], recipient_name: nil)
+    result = MessageGenerator.new(message).generate
+
+    assert_match(/お父さん・お母さんへ/, result)
   end
 
   # --- occasion に応じた導入文 ---


### PR DESCRIPTION
## 概要
Step 1のカテゴリ選択後に、具体的な宛名を選択・自由入力できる二段階選択UIを実装しました。

Closes #54

## やったこと
- `messages`テーブルに`recipient_name`カラム（string, nullable）を追加
- Stimulusコントローラー`recipient_name_controller.js`を新規作成（チップ生成・選択・自由入力）
- Step 1ビューにカテゴリ別の宛名チップ表示エリアと自由入力フィールドを追加
- `_selection_card`パーシャルにオプショナルな`action`データ属性を追加
- コントローラー・Concernで`recipient_name`のセッション保存・Message構築に対応
- `MessageGenerator`の`opening`メソッドで`recipient_name`優先、HONORIFICSフォールバック
- モデル・コントローラー・サービスのテストを追加（バリデーション、セッション保存、生成ロジック）

## テスト結果
- RuboCop: 違反0件
- Brakeman: High/Medium脆弱性なし（Unmaintained Dependencyのみ）
- bundler-audit: Rails 7.0関連の既知の警告のみ
- rails test: 106 runs, 272 assertions, 0 failures

## テスト計画
- [x] カテゴリ選択後に宛名入力セクションが表示される
- [x] チップクリックで宛名が入力される
- [x] テキスト入力で自由な宛名を指定できる
- [x] 宛名未入力でも従来通り進める（HONORIFICSフォールバック）
- [x] 生成メッセージの宛名に`recipient_name`が反映される
- [x] `recipient_name`の長さバリデーション（20文字以内）が動作する

## 依存Issue
- なし