### PR TITLE
ER図をMermaidで作成し本リリース版に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,5 +369,93 @@ https://www.figma.com/design/9QruxKoB77hXPXCXQ9I2O0/KIMOTI-LETTER?node-id=38-177
 
 ## ER図
 
-<!-- TODO: Issue #105 で Mermaid 記法に差し替え予定 -->
-[![Image from Gyazo](https://i.gyazo.com/fe5a627d11c94bd497c5a8bb39ac0611.png)](https://gyazo.com/fe5a627d11c94bd497c5a8bb39ac0611)
+```mermaid
+erDiagram
+    users {
+        bigint id PK
+        string provider "NOT NULL"
+        string uid "NOT NULL"
+        string name "NOT NULL"
+        string email "NOT NULL"
+        string avatar_url
+        integer ai_refine_daily_used "NOT NULL, default: 0"
+        date ai_refine_usage_date
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    messages {
+        bigint id PK
+        bigint user_id FK
+        bigint recipient_id FK "NOT NULL"
+        bigint occasion_id FK "NOT NULL"
+        bigint feeling_id FK "NOT NULL"
+        text episode
+        text additional_message
+        text generated_content
+        text edited_content
+        string recipient_name
+        integer satisfaction_rating
+        string usage_purpose
+        jsonb generated_parts
+        datetime ai_refined_at
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    message_impressions {
+        bigint id PK
+        bigint message_id FK "NOT NULL"
+        bigint impression_id FK "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    recipients {
+        bigint id PK
+        string name "NOT NULL"
+        integer position "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    occasions {
+        bigint id PK
+        string name "NOT NULL"
+        integer position "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    impressions {
+        bigint id PK
+        string name "NOT NULL"
+        integer position "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    feelings {
+        bigint id PK
+        string name "NOT NULL"
+        integer position "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    contacts {
+        bigint id PK
+        string name "NOT NULL"
+        string email "NOT NULL"
+        text message "NOT NULL"
+        datetime created_at "NOT NULL"
+        datetime updated_at "NOT NULL"
+    }
+
+    users ||--o{ messages : "has many"
+    messages }o--|| recipients : "belongs to"
+    messages }o--|| occasions : "belongs to"
+    messages }o--|| feelings : "belongs to"
+    messages ||--o{ message_impressions : "has many"
+    impressions ||--o{ message_impressions : "has many"
+```


### PR DESCRIPTION
## 概要
READMEのER図をGyazo画像からMermaid記法に差し替え、本リリース版のスキーマに合わせて更新しました。

Closes #105

## やったこと
- Gyazo画像リンクとTODOコメントを削除
- `db/schema.rb` の全8テーブル・全カラムをMermaid erDiagram記法で記載
- 外部キーに基づくリレーション（6つ）を矢印で記載
  - users → messages
  - messages → recipients, occasions, feelings
  - messages → message_impressions ← impressions

## テスト結果
- RuboCop: README変更のみのためコード変更なし
- Brakeman: README変更のみのためコード変更なし
- bundler-audit: README変更のみのためコード変更なし
- rails test: README変更のみのためコード変更なし

※ Docker Desktop未起動のためチェック実行不可。本PRはREADME（Markdown）のみの変更でRubyコードの変更はありません。

## テスト計画
- [x] Mermaid記法のER図が全テーブル・全カラムを含んでいること（schema.rbと目視照合済み）
- [x] 外部キーのリレーションが正確に記載されていること
- [x] GitHubのMarkdownプレビューでMermaidが正しくレンダリングされること（push後に確認）

## 依存Issue
- なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)